### PR TITLE
Dockerfile: add gdbserver

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,7 @@ RUN apt install -y --no-install-recommends \
     dnsutils \
     exa \
     file \
+    gdbserver \
     htop \
     i2c-tools \
     iproute2 \


### PR DESCRIPTION
It should be small enough

![image](https://user-images.githubusercontent.com/4013804/168851619-0abae4fb-dea5-48a3-99a8-74e335c026ba.png)

This is one step towards https://github.com/bluerobotics/BlueOS-docker/issues/717