### PR TITLE
Update libcamera gstreamer userland

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM python:3.9-slim-bullseye AS build_gstreamer
 
 # Build and Pre-Install Gstreamer
 COPY ./scripts/build_gst.sh /build_gst.sh
-RUN GST_VERSION=1.20.2 LIBCAMERA_VERSION=v0.0.4 \
+RUN GST_VERSION=1.22.1 LIBCAMERA_VERSION=v0.0.4 \
     ./build_gst.sh && rm /build_gst.sh
 
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM python:3.9-slim-bullseye AS build_gstreamer
 
 # Build and Pre-Install Gstreamer
 COPY ./scripts/build_gst.sh /build_gst.sh
-RUN GST_VERSION=1.20.2 LIBCAMERA_VERSION=ba6435930f08e802cffc688d90f156a8959a0f86 \
+RUN GST_VERSION=1.20.2 LIBCAMERA_VERSION=v0.0.4 \
     ./build_gst.sh && rm /build_gst.sh
 
 

--- a/scripts/build_gst.sh
+++ b/scripts/build_gst.sh
@@ -212,7 +212,7 @@ pip3 install ${GST_PIP_DEPENDENCIES[@]}
 if [ -n "$USERLAND_PATH" ]; then
     git clone https://github.com/raspberrypi/userland.git $USERLAND_PATH
     cd $USERLAND_PATH
-    git checkout c4fd1b8986c6d6d4ae5cd51e65a8bbeb495dfa4e
+    git checkout 54fd97ae4066a10b6b02089bc769ceed328737e0
 
     sed -i "s/sudo//g" buildme  # remove any sudo call
     ./buildme $GST_INSTALL_DIR


### PR DESCRIPTION
Test image of BlueOS using this base: [joaoantoniocardoso/blueos-core:update-libcamera-gstreamer-userland](https://hub.docker.com/layers/joaoantoniocardoso/blueos-core/update-libcamera-gstreamer-userland/images/sha256-77f4fd0699461fb857372c64dc4e7e49b6b232bfaf13c0a16c7c00ff50d04891?context=explore)

## What's changed?

### Userland
It's rolling-release in `master`, but only a build fix since c4fd1b8: https://github.com/raspberrypi/userland/commits/master, and [here's the diff](https://github.com/raspberrypi/userland/compare/c4fd1b8986c6d6d4ae5cd51e65a8bbeb495dfa4e..master).

Outcomes: nothing is expected, since the previous was building fine in our docker.

### Libcamera:

Since [`ba64359`](https://git.libcamera.org/libcamera/libcamera.git/commit/?id=ba6435930f08e802cffc688d90f156a8959a0f86) (a fix I requested because the build was not working properly, merged on 2022-07-06), 509 commits were added. At the time, there were no tags available. A (not so) short summary since the first version was release is available on the following links:
- [v0.0.4](https://git.libcamera.org/libcamera/libcamera.git/tag/?h=v0.0.4)
- [v0.0.3](https://git.libcamera.org/libcamera/libcamera.git/tag/?h=v0.0.3)
- [v0.0.2](https://git.libcamera.org/libcamera/libcamera.git/tag/?h=v0.0.2)
- [v0.0.1](https://git.libcamera.org/libcamera/libcamera.git/tag/?h=v0.0.1)

Outcomes: Since many improvements were made regarding to drivers and compatibility regarding to Raspberry Pis, I expect we encounter fewer weird bugs when dealing with the Raspberry Pi cameras when in legacy mode.

In general

### GStreamer:

1.22 is the following stable from 1.20, and [here](https://gstreamer.freedesktop.org/releases/1.22) is its changelog.

Outcomes: I expect more stability for RTP, RTSP, h264, WebRTC, and video4linux, since there were several fixes/additions relating to them, and we use them all the time. 

We could also boost the supported GStreamer API in mavlink-camera-manager if we need to, gaining access to more convenient helper functions like builders and gaining easier access to some important sub-elements, properties, and signals from big elements like WebRTCBin.