### PR TITLE
Dockerfile: Update GStreamer from 1.22.1 to 1.22.3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM python:3.9-slim-bullseye AS build_gstreamer
 
 # Build and Pre-Install Gstreamer
 COPY ./scripts/build_gst.sh /build_gst.sh
-RUN GST_VERSION=1.22.1 LIBCAMERA_VERSION=v0.0.4 \
+RUN GST_VERSION=1.22.3 LIBCAMERA_VERSION=v0.0.4 \
     ./build_gst.sh && rm /build_gst.sh
 
 


### PR DESCRIPTION
Several fixes on elements that we extensively depend on, more notably:
- WebRTCBin:
    - numerous data race fixes and stability fixes
- RTSPSrc:
  - fix regression with URI protocols in OPTIONS requests for RTSP over TLS
  - improved control url handling compatibility for broken servers
  - Fix handling of * control path
- V4lSrc:
  - Add support for YVU420M format; mark JPEG content as parsed


The full release notes can be checked [here](https://gstreamer.freedesktop.org/news/)
