### PR TITLE
Dockerfile: Add tool: vim

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -48,6 +48,7 @@ RUN apt update && \
         tmux \
         tree \
         unzip \
+        vim \
         watch \
         wget \
     # LIBS:


### PR DESCRIPTION
Since the default Debian configuration is already good and we don't need anything beyond that, I'm simply adding it without any customization.

*The most well-spent 3mb for when I'm rushed*