### PR TITLE
Correct platform name for arm64 docker image

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -19,7 +19,7 @@ jobs:
         docker: [base]
         project: [companion]
         new_project: [blueos]
-        platforms: ["linux/arm/v7,linux/arm/v8,linux/amd64"]
+        platforms: ["linux/arm/v7,linux/arm64/v8,linux/amd64"]
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/scripts/build_gst.sh
+++ b/scripts/build_gst.sh
@@ -19,13 +19,13 @@ LIBCAMERA_ENABLED=${LIBCAMERA_ENABLED:-false}
 LIBCAMERA_VERSION=${LIBCAMERA_VERSION:-master}
 LIBCAMERA_GIT_URL=${LIBCAMERA_GIT_URL:-https://git.libcamera.org/libcamera/libcamera.git}
 ARCH=${ARCH:-$(uname -m)}
+if [[ $ARCH =~ ^(arm|aarch64) ]]; then ARM=true; else ARM=false; fi
 # RPICAM is only supported for arm
-if [[ $ARCH == arm* ]]; then
+if [[ $ARM == true ]]; then
     RPICAM_ENABLED=${RPICAM_ENABLED:-true}
 else
     RPICAM_ENABLED=false
 fi
-
 # Here we carefully select what we want to build/install. Even though several
 # of the listed options are disabled by default, it is interesting to have
 # them here to be documented.
@@ -70,11 +70,7 @@ if [ $GST_OMX_ENABLED == true ]; then
     GST_MESON_OPTIONS+=(
         -D omx=enabled
     )
-    if [[ $ARCH == x86_64 ]]; then
-        GST_MESON_OPTIONS+=(
-            -D gst-omx:target=generic
-        )
-    elif [[ $ARCH == arm* ]]; then
+    if [[ $ARM == true ]]; then
         # To build omx for the "rpi" target, we need to provide the raspberrypi
         # IL headers:
         USERLAND_PATH=/tmp/userland
@@ -82,7 +78,11 @@ if [ $GST_OMX_ENABLED == true ]; then
             -D gst-omx:target=rpi
             -D gst-omx:header_path=$USERLAND_PATH/interface/vmcs_host/khronos/IL
         )
-    fi
+    else
+        GST_MESON_OPTIONS+=(
+            -D gst-omx:target=generic
+        )
+    fi 
 fi
 if [ $LIBCAMERA_ENABLED == true ]; then
     GST_MESON_OPTIONS+=(

--- a/scripts/inspect_gst_plugins.sh
+++ b/scripts/inspect_gst_plugins.sh
@@ -47,7 +47,8 @@ PLUGINS=(
 ARCH=${ARCH:-$(uname -m)}
 GST_OMX_ENABLED=${GST_OMX_ENABLED:-true}
 LIBCAMERA_ENABLED=${LIBCAMERA_ENABLED:-false}
-if [[ $ARCH == arm* ]]; then
+if [[ $ARCH =~ ^(arm|aarch64) ]]; then ARM=true; else ARM=false; fi
+if [[ $ARM == true ]]; then
     RPICAM_ENABLED=${RPICAM_ENABLED:-true}
 
     if [ $RPICAM_ENABLED == true ] && [ -f /dev/vchiq ]; then


### PR DESCRIPTION
When building with `podman-compose` on my Mac, I was seeing the below issue:
```
[2/3] STEP 1/3: FROM docker.io/bluerobotics/blueos-base:v0.0.10 AS downloadBinaries
Trying to pull docker.io/bluerobotics/blueos-base:v0.0.10...
Error: creating build container: choosing an image from manifest list docker://bluerobotics/blueos-base:v0.0.10: no image found in image index for architecture arm64, variant "v8", OS linux

exit code: 125
```

I believe this is because the wrong platform string is provided.