### PR TITLE
Dockerifle: Update to python 3.11

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.9-slim-bullseye AS build_gstreamer
+FROM python:3.11.7-slim-bullseye AS build_gstreamer
 
 # Build and Pre-Install Gstreamer
 COPY ./scripts/build_gst.sh /build_gst.sh
@@ -6,7 +6,7 @@ RUN GST_VERSION=1.22.3 LIBCAMERA_VERSION=v0.0.4 \
     ./build_gst.sh && rm /build_gst.sh
 
 
-FROM python:3.9-slim-bullseye AS main
+FROM python:3.11.7-slim-bullseye AS main
 
 
 # Setup the user environment


### PR DESCRIPTION
Python 3.7 is already in EOL. We should move to a new version.