### PR TITLE
Correct platform name

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -19,7 +19,7 @@ jobs:
         docker: [base]
         project: [companion]
         new_project: [blueos]
-        platforms: ["linux/arm/v7,linux/arm/v8,linux/amd64"]
+        platforms: ["linux/arm/v7,linux/arm64,linux/amd64"]
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM python:3.11.7-slim-bullseye AS build_gstreamer
 # Build and Pre-Install Gstreamer
 COPY ./scripts/build_gst.sh /build_gst.sh
 RUN GST_VERSION=1.24.1 \
-    LIBCAMERA_VERSION=v0.2.0 LIBCAMERA_ENABLED=true \
+    LIBCAMERA_VERSION=v0.3.0 LIBCAMERA_ENABLED=true \
     RPICAM_ENABLED=false \
     GST_OMX_ENABLED=false \
     ./build_gst.sh && rm /build_gst.sh

--- a/scripts/build_gst.sh
+++ b/scripts/build_gst.sh
@@ -19,11 +19,11 @@ LIBCAMERA_ENABLED=${LIBCAMERA_ENABLED:-false}  # FIXME: libcamera is failing to 
 LIBCAMERA_VERSION=${LIBCAMERA_VERSION:-master}
 LIBCAMERA_GIT_URL=${LIBCAMERA_GIT_URL:-https://git.libcamera.org/libcamera/libcamera.git}
 ARCH=${ARCH:-$(uname -m)}
+
+if [[ $ARCH =~ ^(arm|aarch64) ]]; then ARM=true; else ARM=false; fi
+
 # RPICAM is only supported for arm
-RPICAM_ENABLED=${RPICAM_ENABLED:-false}
-if [[ $ARCH != arm* ]]; then
-    RPICAM_ENABLED=false
-fi
+RPICAM_ENABLED=${RPICAM_ENABLED:-$ARM}
 
 # Here we carefully select what we want to build/install. Even though several
 # of the listed options are disabled by default, it is interesting to have
@@ -73,11 +73,7 @@ if [ $GST_OMX_ENABLED == true ]; then
     GST_MESON_OPTIONS+=(
         -D omx=enabled
     )
-    if [[ $ARCH == x86_64 ]]; then
-        GST_MESON_OPTIONS+=(
-            -D gst-omx:target=generic
-        )
-    elif [[ $ARCH == arm* ]]; then
+    if [[ $ARM == true ]]; then
         # To build omx for the "rpi" target, we need to provide the raspberrypi
         # IL headers:
         USERLAND_PATH=/tmp/userland
@@ -85,7 +81,11 @@ if [ $GST_OMX_ENABLED == true ]; then
             -D gst-omx:target=rpi
             -D gst-omx:header_path=$USERLAND_PATH/interface/vmcs_host/khronos/IL
         )
-    fi
+    else
+        GST_MESON_OPTIONS+=(
+            -D gst-omx:target=generic
+        )
+    fi 
 fi
 if [ $LIBCAMERA_ENABLED == true ]; then
     GST_MESON_OPTIONS+=(

--- a/scripts/inspect_gst_plugins.sh
+++ b/scripts/inspect_gst_plugins.sh
@@ -47,7 +47,8 @@ PLUGINS=(
 ARCH=${ARCH:-$(uname -m)}
 GST_OMX_ENABLED=${GST_OMX_ENABLED:-false}
 LIBCAMERA_ENABLED=${LIBCAMERA_ENABLED:-false}
-if [[ $ARCH == arm* ]]; then
+if [[ $ARCH =~ ^(arm|aarch64) ]]; then ARM=true; else ARM=false; fi
+if [[ $ARM == true ]]; then
     RPICAM_ENABLED=${RPICAM_ENABLED:-false}
 
     if [ $RPICAM_ENABLED == true ] && [ -f /dev/vchiq ]; then


### PR DESCRIPTION
When building with `podman-compose` on my Mac, I was seeing the below issue:
```
[2/3] STEP 1/3: FROM docker.io/bluerobotics/blueos-base:v0.0.10 AS downloadBinaries
Trying to pull docker.io/bluerobotics/blueos-base:v0.0.10...
Error: creating build container: choosing an image from manifest list docker://bluerobotics/blueos-base:v0.0.10: no image found in image index for architecture arm64, variant "v8", OS linux

exit code: 125
```

I believe this is because the wrong platform string is provided.