### PR TITLE
Deploy refactoring

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,136 +1,191 @@
 name: Test, Build and Deploy Images
 
 env:
+  PROJECT: blueos
+  DOCKER: base
   DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
+  IMAGE_LIMIT_SIZE_MB: 600
+  ARTIFACTS_PATH: /tmp/artifacts
+  DIGESTS_PATH: /tmp/digests
 
 on:
-    workflow_dispatch:
-    pull_request:
-    push:
-    schedule:
+  workflow_dispatch:
+  pull_request:
+  push:
+  schedule:
     # Run every 6 days to keep our caches alive
     - cron: '0 0 */6 * *'
 
 jobs:
-  deploy-docker-images:
-    runs-on: ubuntu-latest
+  build:
+    runs-on: ubuntu-22.04
+
     strategy:
       matrix:
-        docker: [base]
-        project: [companion]
-        new_project: [blueos]
-        platforms: ["linux/arm/v7,linux/arm64,linux/amd64"]
+        platform:
+          - linux/arm/v7
+          - linux/arm64
+          - linux/amd64
+
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Prepare
         id: prepare
         run: |
-          # Deploy image with the name of the branch, if the build is a git tag, replace tag with the tag name.
-          # If git tag matches semver, append latest tag to the push.
-          DOCKER_IMAGE=${DOCKER_USERNAME:-bluerobotics}/${{ matrix.project }}-${{ matrix.docker }}
-          VERSION=${GITHUB_REF##*/}
+          echo "buildx_args=VUE_APP_GIT_DESCRIBE=$(git describe --long --always --dirty --all)" >> $GITHUB_OUTPUT
 
-          if [[ $GITHUB_REF == refs/tags/* ]]; then
-            VERSION=${GITHUB_REF#refs/tags/}
-          fi
+          echo "DOCKER_IMAGE=${DOCKER_USERNAME:-bluerobotics}/${PROJECT}-${DOCKER}" >> $GITHUB_ENV
 
-          TAGS="--tag ${DOCKER_IMAGE}:${VERSION}"
-          if [[ $VERSION =~ ^[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}$ ]]; then
-            TAGS="$TAGS --tag ${DOCKER_IMAGE}:latest"
-          fi
+          mkdir -p "${ARTIFACTS_PATH}"
+          mkdir -p "${DIGESTS_PATH}"
 
-          # Add temporary tag for the new project name
-          TAGS="$TAGS --tag ${DOCKER_USERNAME:-bluerobotics}/${{ matrix.new_project }}-${{ matrix.docker }}:${VERSION}"
-          echo ::set-output name=docker_image::${DOCKER_IMAGE}
-          echo ::set-output name=version::${VERSION}
-          echo ::set-output name=buildx_args:: \
-            --build-arg VUE_APP_GIT_DESCRIBE=$(git describe --long --always --dirty --all) \
-            --cache-from "type=local,src=/tmp/.buildx-cache" \
-            --cache-to "type=local,dest=/tmp/.buildx-cache" \
-            ${TAGS} \
-            --file Dockerfile .
+          platform=${{ matrix.platform }}
+          echo "PLATFORM_PAIR=${platform//\//-}" >> $GITHUB_ENV
+
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.DOCKER_IMAGE }}
+          tags: |
+            type=ref,event=branch
+            type=ref,event=pr
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v1
+        uses: docker/setup-qemu-action@v3
         with:
           platforms: all
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v3
         with:
           version: latest
 
-      - name: Cache Docker layers
-        uses: actions/cache@v2
+      - name: Cache
+        uses: actions/cache@v4
         id: cache
         with:
-          path: /tmp/.buildx-cache
-          key: ${{ runner.os }}-buildx-${{ matrix.docker }}-${{ hashFiles('Dockerfile') }}
-          restore-keys: |
-            ${{ runner.os }}-buildx-${{ matrix.docker }}-${{ hashFiles('Dockerfile') }}
-            ${{ runner.os }}-buildx-${{ matrix.docker }}
+          path: |
+            var-cache-apt
+            var-lib-apt
+            var-ccache
+          key: ${{ env.PLATFORM_PAIR }}-cache-${{ hashFiles('Dockerfile') }}
+          restore-keys: ${{ env.PLATFORM_PAIR }}-cache-
 
-      - name: Docker Buildx (build)
-        run: |
-          # Pull latest version of image to help with build speed
-          IFS=',' read -ra platforms <<< "${{ matrix.platforms }}"
-          for platform in "${platforms[@]}"; do
-            docker pull --platform ${platform} ${DOCKER_USERNAME:-bluerobotics}/${{ matrix.project }}-${{ matrix.docker }}:master || true
-          done
-          docker buildx build \
-            --output "type=image,push=false" \
-            --platform ${{ matrix.platforms }} \
-            ${{ steps.prepare.outputs.buildx_args }}
-
-      - name: Check size
-        run: |
-          # Check if the image size is lower than our limit
-          docker image list
-          IMAGE_ID=$(docker images -q ${DOCKER_USERNAME:-bluerobotics}/${{ matrix.project }} | head -n 1)
-          LIMIT_SIZE_MB=600
-          IMAGE_SIZE_MB=$(( $(docker inspect $IMAGE_ID --format {{.Size}})/(2**20) ))
-          echo "Core size is: $IMAGE_SIZE_MB MB"
-          ((IMAGE_SIZE_MB < LIMIT_SIZE_MB))
+      - name: Inject cache into Docker
+        uses: reproducible-containers/buildkit-cache-dance@v3
+        with:
+          cache-map: |
+            {
+              "var-cache-apt": "/var/cache/apt",
+              "var-lib-apt": "/var/lib/apt",
+              "var-ccache": "~/.cache"
+            }
+          skip-extraction: ${{ steps.cache.outputs.cache-hit }}
 
       - name: Login to DockerHub
         if: success() && github.event_name != 'pull_request'
-        uses: crazy-max/ghaction-docker-login@v1
+        uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
 
-      - name: Docker Buildx (push)
-        if: success() && github.event_name != 'pull_request'
+      - name: Build and push
+        id: build
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: Dockerfile
+          platforms: ${{ matrix.platform }}
+          labels: ${{ steps.meta.outputs.labels }}
+          push: ${{ github.event_name != 'pull_request' }}
+          outputs: type=docker,dest=${{ env.ARTIFACTS_PATH }}/${{ env.PLATFORM_PAIR }}.tar
+          build-args: ${{ steps.prepare.outputs.buildx_args }}
+          tags: ${{ steps.meta.outputs.tags }}
+          cache-from: type=gha,scope=${{ env.PLATFORM_PAIR }}
+          cache-to: type=gha,scope=${{ env.PLATFORM_PAIR }},mode=max
+
+      - name: Export digest
         run: |
-          docker buildx build \
-            --output "type=image,push=true" \
-            --platform ${{ matrix.platforms }} \
-            ${{ steps.prepare.outputs.buildx_args }}
+          digest="${{ steps.build.outputs.digest }}"
+          touch "${{ env.DIGESTS_PATH }}/${digest#sha256:}"
+
+      - name: Upload digest
+        uses: actions/upload-artifact@v4
+        with:
+          name: digests-${{ env.PLATFORM_PAIR }}
+          path: ${{ env.DIGESTS_PATH }}/*
+          if-no-files-found: error
+          retention-days: 1
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ env.PROJECT }}-${{ env.DOCKER }}-${{ env.PLATFORM_PAIR }}
+          path: ${{ env.ARTIFACTS_PATH }}/*.tar
+          if-no-files-found: error
+
+      - name: Check size
+        run: |
+          image_name=$(docker load --input ${{ env.ARTIFACTS_PATH }}/*.tar | awk '{print $3}')
+
+          IMAGE_SIZE_BYTES=$(docker image inspect $image_name --format "{{json .Size}}")
+          IMAGE_SIZE_MB=$((IMAGE_SIZE_BYTES / 1024 / 1024))
+
+          echo "Core size is: ${IMAGE_SIZE_MB} MB"
+          echo "Core size limit: ${IMAGE_LIMIT_SIZE_MB} MB"
+          if [ "$IMAGE_SIZE_MB" -gt "$IMAGE_LIMIT_SIZE_MB" ]; then
+            echo "::error::Image size is larger than the limit"
+          fi
+
+  merge:
+    runs-on: ubuntu-22.04
+    needs:
+      - build
+    steps:
+      - name: Download digests
+        uses: actions/download-artifact@v4
+        with:
+          path: ${{ env.DIGESTS_PATH }}
+          pattern: digests-*
+          merge-multiple: true
+
+      - name: Delete digests
+        uses: geekyeggo/delete-artifact@v5
+        with:
+            name: digests-*
+            useGlob: true
+            failOnError: false
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Prepare
+        id: prepare
+        run: echo "DOCKER_IMAGE=${DOCKER_USERNAME:-bluerobotics}/${PROJECT}-${DOCKER}" >> $GITHUB_ENV
+
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.DOCKER_IMAGE }}
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        if: success() && github.event_name != 'pull_request'
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+
+      - name: Create manifest list and push
+        if: success() && github.event_name != 'pull_request'
+        working-directory: ${{ env.DIGESTS_PATH }}
+        run: docker buildx imagetools create $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") $(printf '${{ env.DOCKER_IMAGE }}@sha256:%s ' *)
 
       - name: Inspect image
         if: always() && github.event_name != 'pull_request'
-        run: |
-          docker buildx imagetools \
-            inspect ${{ steps.prepare.outputs.docker_image }}:${{ steps.prepare.outputs.version }}
-
-      - name: Create image artifact
-        # We are serializing each export here because "Currently, multi-platform images cannot be
-        # exported with the docker export type." (https://docs.docker.com/engine/reference/commandline/buildx_build/#output)
-        run: |
-          DOCKER_IMAGE=${DOCKER_USERNAME:-bluerobotics}/${{ matrix.project }}-${{ matrix.docker }}
-          GIT_HASH_SHORT=$(git rev-parse --short "$GITHUB_SHA")
-          IFS=',' read -ra platforms <<< "${{ matrix.platforms }}"
-          for platform in "${platforms[@]}"; do
-            docker buildx build \
-              --platform $platform \
-              ${{ steps.prepare.outputs.buildx_args }} \
-              --tag ${DOCKER_IMAGE}:${GIT_HASH_SHORT} \
-              --output "type=docker,dest=BlueOS-base-${GIT_HASH_SHORT}.tar"
-          done
-
-      - name: Upload artifact
-        uses: actions/upload-artifact@v2
-        with:
-          name: BlueOS-base-docker-image.zip
-          path: '*.tar'
+        run: docker buildx imagetools inspect ${{ env.DOCKER_IMAGE }}:${{ steps.meta.outputs.version }} --format "{{json .}}" | jq

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -34,8 +34,6 @@ jobs:
       - name: Prepare
         id: prepare
         run: |
-          echo "buildx_args=VUE_APP_GIT_DESCRIBE=$(git describe --long --always --dirty --all)" >> $GITHUB_OUTPUT
-
           echo "DOCKER_IMAGE=${DOCKER_USERNAME:-bluerobotics}/${PROJECT}-${DOCKER}" >> $GITHUB_ENV
 
           mkdir -p "${ARTIFACTS_PATH}"
@@ -104,7 +102,6 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           push: ${{ github.event_name != 'pull_request' }}
           outputs: type=docker,dest=${{ env.ARTIFACTS_PATH }}/${{ env.PLATFORM_PAIR }}.tar
-          build-args: ${{ steps.prepare.outputs.buildx_args }}
           tags: ${{ steps.meta.outputs.tags }}
           cache-from: type=gha,scope=${{ env.PLATFORM_PAIR }}
           cache-to: type=gha,scope=${{ env.PLATFORM_PAIR }},mode=max

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -4,7 +4,7 @@ env:
   PROJECT: blueos
   DOCKER: base
   DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
-  IMAGE_LIMIT_SIZE_MB: 600
+  IMAGE_LIMIT_SIZE_MB: 900
   ARTIFACTS_PATH: /tmp/artifacts
   DIGESTS_PATH: /tmp/digests
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,115 +1,138 @@
-FROM python:3.11.7-slim-bullseye AS build_gstreamer
+# Global build environment variables
+ARG GST_INSTALL_DIR=/artifacts
+ARG GST_VERSION=1.24.1
+ARG LIBCAMERA_ENABLED=true
+ARG LIBCAMERA_VERSION=v0.3.0
+ARG RPICAM_ENABLED=false
+ARG GST_OMX_ENABLED=false
 
-# Build and Pre-Install Gstreamer
+
+# Stage 1: Base Image
+FROM python:3.11.7-slim-bullseye AS base
+
+RUN <<-EOF
+set -e
+    # Add backports
+    echo "deb http://deb.debian.org/debian bullseye-backports main contrib non-free" >> "/etc/apt/sources.list"
+
+    # Setup cache
+    rm -f /etc/apt/apt.conf.d/docker-clean
+    echo 'Binary::apt::APT::Keep-Downloaded-Packages "true";' >/etc/apt/apt.conf.d/keep-cache
+EOF
+
+
+# Stage 2: Build GStreamer
+FROM base AS gstreamer
+
+ARG GST_INSTALL_DIR
+ARG GST_VERSION
+ARG LIBCAMERA_ENABLED
+ARG LIBCAMERA_VERSION
+ARG RPICAM_ENABLED
+ARG GST_OMX_ENABLED
+
 COPY ./scripts/build_gst.sh /build_gst.sh
-RUN GST_VERSION=1.24.1 \
-    LIBCAMERA_VERSION=v0.3.0 LIBCAMERA_ENABLED=true \
-    RPICAM_ENABLED=false \
-    GST_OMX_ENABLED=false \
-    ./build_gst.sh && rm /build_gst.sh
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+    --mount=type=cache,target=/var/lib/apt,sharing=locked \
+    --mount=type=cache,target=/root/.cache,sharing=locked \
+    ./build_gst.sh \
+    && rm -f /build_gst.sh
 
 
-FROM python:3.11.7-slim-bullseye AS main
+# Stage 3: Final Image
+FROM base AS main
 
+ARG GST_INSTALL_DIR
+ARG LIBCAMERA_ENABLED
+ARG RPICAM_ENABLED
 
 # Setup the user environment
-RUN mkdir -p /home/pi && \
-    RCFILE_PATH="/etc/blueosrc" && \
-    echo "alias cat='batcat --paging=never'" >> $RCFILE_PATH && \
-    echo "alias ls=exa" >> $RCFILE_PATH && \
-    echo "cd ~" >> $RCFILE_PATH && \
-    echo "source $RCFILE_PATH" >> /etc/bash.bashrc
+RUN <<-EOF
+set -e
+    RCFILE_PATH="/etc/blueosrc"
+    echo "alias cat='batcat --paging=never'" >> "$RCFILE_PATH"
+    echo "alias ls=exa" >> "$RCFILE_PATH"
+    echo "cd ~" >> "$RCFILE_PATH"
+    echo "source $RCFILE_PATH" >> "/etc/bash.bashrc"
+EOF
 
-# Add backports
-RUN echo "deb http://deb.debian.org/debian bullseye-backports main contrib non-free" | tee -a /etc/apt/sources.list
-
-# Install necessary tools and libs for basic use
-# Note: Remove iotop if htop is newer 3.2+
-RUN apt update && \
-    apt install --assume-yes --no-install-recommends \
-    # TOOLS:
-        bat \
-        bzip2 \
-        curl \
-        dnsmasq \
-        dnsutils \
-        exa \
-        file \
-        gdbserver \
-        gettext \
-        hostapd \
-        htop \
-        i2c-tools \
-        ifmetric \
-        iotop \
-        iproute2 \
-        iperf3 \
-        iputils-ping \
-        iw \
-        jq \
-        less \
-        libudev-dev \
-        locate \
-        lsof \
-        mtr \
-        nano \
-        net-tools \
-        nginx \
-        parallel \
-        rsync \
-        screen \
-        ssh \
-        sshpass \
-        sudo \
-        tmux \
-        tree \
-        unzip \
-        vim \
-        watch \
-        wget \
-    # LIBS:
-        libatm1 \
-        libavcodec58 \
-        libavfilter7 \
-        libavformat58 \
-        libavutil56 \
-        libde265-0 \
-        libdrm2 \
-        libdv4 \
-        libglib2.0-0 \
-        libgudev-1.0-0 \
-        libjson-glib-1.0-0 \
-        libogg0 \
-        libopenjp2-7 \
-        libopus0 \
-        libpulse0 \
-        libsrtp2-1 \
-        libtcl8.6 \
-        libvorbis0a \
-        libtk8.6 \
-        libv4l-0 \
-        libva-drm2/bullseye-backports \
-        libva-glx2/bullseye-backports \
-        libva-wayland2/bullseye-backports \
-        libva-x11-2/bullseye-backports \
-        libva2/bullseye-backports \
-        libvpx6 \
-        libyaml-0-2 \
-        libx264-160 \
-        libx265-192 \
-        libxml2 \
-    # Clean it
-    && apt-get clean && rm -rf /var/lib/apt/lists/*
-
-# Install Pre-built GStreamer
-COPY --from=build_gstreamer /artifacts/. /.
-
-# Update links for the installed libraries and check if GStreamer is setup correctly
-COPY ./scripts/inspect_gst_plugins.sh /inspect_gst_plugins.sh
-RUN ldconfig && \
-    LIBCAMERA_ENABLED=true RPICAM_ENABLED=false GST_OMX_ENABLED=false /inspect_gst_plugins.sh && \
-    mkdir -p /home/pi/tools && \
-    mv /inspect_gst_plugins.sh /home/pi/tools/.
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+    --mount=type=cache,target=/var/lib/apt,sharing=locked \
+    # Install necessary tools and libs for basic use
+        apt-get update \
+        && apt-get install --assume-yes --no-install-recommends \
+        # TOOLS:
+            bat \
+            bzip2 \
+            curl \
+            dnsmasq \
+            dnsutils \
+            exa \
+            file \
+            gdbserver \
+            gettext \
+            hostapd \
+            htop \
+            i2c-tools \
+            ifmetric \
+            # Note: Remove iotop if htop is newer 3.2+
+            iotop \
+            iproute2 \
+            iperf3 \
+            iputils-ping \
+            iw \
+            jq \
+            less \
+            libudev-dev \
+            locate \
+            lsof \
+            mtr \
+            nano \
+            net-tools \
+            nginx \
+            parallel \
+            rsync \
+            screen \
+            ssh \
+            sshpass \
+            sudo \
+            tmux \
+            tree \
+            unzip \
+            vim \
+            watch \
+            wget \
+        # LIBS:
+            libatm1 \
+            libavcodec58 \
+            libavfilter7 \
+            libavformat58 \
+            libavutil56 \
+            libde265-0 \
+            libdrm2 \
+            libdv4 \
+            libglib2.0-0 \
+            libgudev-1.0-0 \
+            libjson-glib-1.0-0 \
+            libogg0 \
+            libopenjp2-7 \
+            libopus0 \
+            libpulse0 \
+            libsrtp2-1 \
+            libtcl8.6 \
+            libvorbis0a \
+            libtk8.6 \
+            libv4l-0 \
+            libva-drm2/bullseye-backports \
+            libva-glx2/bullseye-backports \
+            libva-wayland2/bullseye-backports \
+            libva-x11-2/bullseye-backports \
+            libva2/bullseye-backports \
+            libvpx6 \
+            libyaml-0-2 \
+            libx264-160 \
+            libx265-192 \
+            libxml2
 
 # Install some tools
 COPY ./scripts/install_viu.sh /install_viu.sh
@@ -120,3 +143,13 @@ RUN ./install_gping.sh && rm /install_gping.sh
 
 COPY ./scripts/install_simple_http_server.sh /install_simple_http_server.sh
 RUN ./install_simple_http_server.sh && rm /install_simple_http_server.sh
+
+# Install Pre-built GStreamer
+COPY --from=gstreamer /artifacts/. /.
+
+# Update links for the installed libraries and check if GStreamer is setup correctly
+COPY ./scripts/inspect_gst_plugins.sh /inspect_gst_plugins.sh
+RUN ldconfig \
+    && /inspect_gst_plugins.sh \
+    && mkdir -p /home/pi/tools \
+    && mv /inspect_gst_plugins.sh /home/pi/tools/.

--- a/scripts/build_gst.sh
+++ b/scripts/build_gst.sh
@@ -119,6 +119,7 @@ GST_BUILD_TOOLS_DEFAULT=(
     apt-transport-https
     bison
     ca-certificates
+    ccache
     cmake
     curl
     flex
@@ -243,6 +244,10 @@ if [ -n "$USERLAND_PATH" ]; then
 
     cd $OLDPWD
 fi
+
+# Setup ccache
+update-ccache-symlinks
+echo 'export PATH="/usr/lib/ccache:$PATH"'
 
 # Download, build, and pre-install Gstreamer
 

--- a/scripts/build_gst.sh
+++ b/scripts/build_gst.sh
@@ -246,9 +246,11 @@ fi
 
 # Download, build, and pre-install Gstreamer
 
+GSTREAMER_GIT_DIR=/tmp/gstreamer
+
 git clone --branch $GST_VERSION --single-branch --depth=1 \
-    $GST_GIT_URL gstreamer
-cd gstreamer
+    $GST_GIT_URL $GSTREAMER_GIT_DIR
+cd $GSTREAMER_GIT_DIR
 
 if [ $LIBCAMERA_ENABLED == true ]; then
     cat << EOF > subprojects/libcamera.wrap
@@ -275,7 +277,3 @@ for file in ${GST_RTSP_HELPERS[@]}; do
     install -Dm755 $GST_BUILD_DIR/subprojects/gst-rtsp-server/examples/$file \
         $GST_INSTALL_DIR/usr/local/bin/$file
 done
-
-# Clean the docker image
-rm -rf build
-apt autoremove -y

--- a/scripts/inspect_gst_plugins.sh
+++ b/scripts/inspect_gst_plugins.sh
@@ -4,6 +4,15 @@ function clear_cache {
     rm -rf ~/.cache/gstreamer-1.0/registry.*.bin
 }
 
+GST_OMX_ENABLED=${GST_OMX_ENABLED:-false}
+LIBCAMERA_ENABLED=${LIBCAMERA_ENABLED:-false}
+ARCH=${ARCH:-$(uname -m)}
+
+if [[ $ARCH =~ ^(arm|aarch64) ]]; then ARM=true; else ARM=false; fi
+
+# RPICAM is only supported for arm
+RPICAM_ENABLED=${RPICAM_ENABLED:-$ARM}
+
 PLUGINS=(
     appsink
     capsfilter
@@ -44,32 +53,16 @@ PLUGINS=(
     x265enc
 )
 
-ARCH=${ARCH:-$(uname -m)}
-GST_OMX_ENABLED=${GST_OMX_ENABLED:-false}
-LIBCAMERA_ENABLED=${LIBCAMERA_ENABLED:-false}
-if [[ $ARCH =~ ^(arm|aarch64) ]]; then ARM=true; else ARM=false; fi
-if [[ $ARM == true ]]; then
-    RPICAM_ENABLED=${RPICAM_ENABLED:-false}
-
-    if [ $RPICAM_ENABLED == true ] && [ -f /dev/vchiq ]; then
-        # This test needs to be run in a Raspberry Pi hardware to work.
-        PLUGINS+=(
-            rpicamsrc
-        )
-    fi
-
-    if [ $GST_OMX_ENABLED == true ]; then
-        PLUGINS+=(
-            omxh264enc
-        )
-    fi
-
-else
-    RPICAM_ENABLED=false
+if [ $RPICAM_ENABLED == true ] && [ -f /dev/vchiq ]; then
+    # This test needs to be run in a Raspberry Pi hardware to work.
+    PLUGINS+=(
+        rpicamsrc
+    )
 fi
 
 if [ $GST_OMX_ENABLED == true ]; then
     PLUGINS+=(
+        omxh264enc
         omx
     )
 fi


### PR DESCRIPTION
This patch refactors the Dockerfile and the CI workflow to improve build speed.

### Old
- Worst possible time <sup><sup>[ref](https://github.com/bluerobotics/blueos-docker-base/actions/runs/5837343949/workflow)</sup></sup>: ~5h 49m 
- Best possible time <sup><sup>[ref](https://github.com/bluerobotics/blueos-docker-base/actions/runs/8669364209/workflow)</sup></sup>: ~2h 32m 

### New
- Worst possible time: ~2h
- Best possible time <sup><sup>[ref](https://github.com/joaoantoniocardoso/blueos-docker-base/actions/runs/9238746206)</sup></sup>: ~2m

E.g.:
- Adding `cmatrix` to BlueOs-base APT dependencies: <10m
- Upgrading GST version to `1.24.3`: ~1h 40m

### General improvements:
1. multi-staging
2. caching
3. build strategy
4. Dockerfile syntax
5. Dockerfile variable handling

### Bugs fixed:
1. The current workflow is not properly storing each platform artifact because the artifacts have the same name
2. Correctly compute the image size. The `master` image size for x86_64 is 793MB, so the limit had to be increased to 900MB

### Techniques implemented:
1. Parallelizes the Docker build for each platform.

2. Uses GitHub cache storage for Docker caching for each platform.

3. Uses GitHub cache storage for APT cache for each platform, and by doing so, we share the downloaded packages between different Docker stages and/or incremental changes. Also, because we are storing all apt packages outside the container, we don't need to clean the container, ensuring we have thinner layers.

4. Uses GitHub cache storage for user cache for each platform, including ccache and pip.

5. Uses global variables to apply the same configuration to each Docker stage.

6. Builds GStreamer in `/tmp` folder so it doesn't bloat the image.

### Other techniques tested:
1. Using apt-fast: it really does speed up the apt layers, but the additional complexity doesn't seem to pay off: (1) sometimes it just fails to download (configured with 16 parallel connections, no mirrors configured); (2) the apt caching strategy already helped a lot; and (3) because GSTreamer is so painful to build, the total time of apt is just a fraction (at least 1/10).

2. Moving the gst_build.sh script into the Dockerfile GST build stage, splitting the single layer into many, making better use of the Docker cache when we change GSreamer configurations and versions. I dropped this because we are always rebuilding 100% of GStreamer when we change versions, and GStreamer is the longest part of this build, so it didn't seem to be worth keeping this change, as a shell script is much more readable and easier to maintain than a Dockerfile.

3. I tried to pass the digests using the cache storage, but there is no easy way to make this work, artifacts are simpler. I choose to display an error annotation instead of making the deployment fail, as we will need the images somewhere to optimize them in case the size is bigger than the limit.

### Things that can be improved:
1. We could experiment with caching the meson builddir or their subprojects somehow, but it seems hard.
