### PR TITLE
Dockerfile: add libatomic1 package

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -104,6 +104,7 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
             wget \
         # LIBS:
             libatm1 \
+            libatomic1 \
             libavcodec59 \
             libavfilter8 \
             libavformat59 \


### PR DESCRIPTION
this is required for using the remote VSCode tools It takes additional 36Kb of disk, which I think is fair for not having to install it on every single image we work with.
![image](https://github.com/bluerobotics/blueos-docker-base/assets/4013804/63f21666-17ec-4e81-bfb0-409e307a2683)
