### PR TITLE
Dockerfile: Strip headless-irrelevant files from final image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -50,6 +50,21 @@ ARG GST_INSTALL_DIR
 ARG LIBCAMERA_ENABLED
 ARG RPICAM_ENABLED
 
+# Strip files that serve no purpose in a headless embedded image. The
+# dpkg path-exclude directive prevents these from ever being unpacked,
+# saving I/O during install and keeping layers small. This config
+# persists into downstream images (e.g. blueos-core).
+RUN cat >/etc/dpkg/dpkg.cfg.d/strip-headless <<'DPKG'
+path-exclude=/usr/share/doc/*
+path-include=/usr/share/doc/*/copyright
+path-exclude=/usr/share/man/*
+path-exclude=/usr/share/fonts/*
+path-exclude=/usr/share/X11/*
+path-exclude=/usr/share/tcltk/*
+path-exclude=/usr/share/libmysofa/*
+path-exclude=/usr/share/libthai/*
+DPKG
+
 # Setup the user environment
 RUN <<-EOF
 set -e
@@ -150,7 +165,11 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
             libx265-199 \
             libxml2 \
     && apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* \
-    && ln -sf /usr/bin/vim.tiny /usr/bin/vim
+    && ln -sf /usr/bin/vim.tiny /usr/bin/vim \
+    # Remove dirs whose postinst scripts break with dpkg path-exclude.
+    # icons (adwaita-icon-theme) and mime (shared-mime-info) must be
+    # installed first then stripped, unlike the dirs handled by dpkg.cfg.
+    && rm -rf /usr/share/icons /usr/share/mime
 
 # Install some tools
 COPY --link ./scripts/install_viu.sh /install_viu.sh


### PR DESCRIPTION
## Summary

Add a dpkg path-exclude config that prevents docs, man pages, fonts, X11 data, tcltk, libmysofa, and libthai files from being unpacked during `apt-get install`. This config persists into downstream images (e.g. blueos-core).

Icons and mime dirs are removed post-install instead, because their packages' `postinst` scripts (`adwaita-icon-theme`, `shared-mime-info`) fail if the target directories are excluded by dpkg.

Saves ~32 MB in the base image; downstream images benefit as well since the dpkg config carries over to their `apt-get install` calls.

---

This change is part of the development branch that improved WebRTC performance in BlueOS.

This change was done as an opportunistic improvement to the ecosystem and has zero impact on the tested performance improvements.

The reduction in size is around 10MB compressed.