### PR TITLE
Add dev build/push scripts for faster offline development

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 scripts/gstreamer
 .idea/
+.buildx-cache/

--- a/dev-build.sh
+++ b/dev-build.sh
@@ -1,0 +1,122 @@
+#!/usr/bin/env bash
+#
+# Build blueos-base and blueos-core locally without pushing to any registry.
+# Optionally deploy the resulting image to a target device.
+#
+# Usage:
+#   ./dev-build.sh                                 # build both images
+#   ./dev-build.sh --deploy pi@192.168.2.2         # build + deploy to target
+#   ./dev-build.sh --base-only                     # build only blueos-base
+#   PLATFORM=linux/arm/v7 ./dev-build.sh           # target armv7
+#   CORE_DIR=../BlueOS-docker/core ./dev-build.sh  # custom core path
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+PLATFORM="${PLATFORM:-linux/arm64}"
+BASE_TAG="${BASE_TAG:-blueos-base:dev}"
+CORE_TAG="${CORE_TAG:-blueos-core:dev}"
+CORE_DIR="${CORE_DIR:-${SCRIPT_DIR}/../BlueOS-docker/core}"
+CACHE_DIR="${CACHE_DIR:-${SCRIPT_DIR}/.buildx-cache}"
+
+DEPLOY_TARGET=""
+BASE_ONLY=false
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --deploy)
+            DEPLOY_TARGET="$2"
+            shift 2
+            ;;
+        --base-only)
+            BASE_ONLY=true
+            shift
+            ;;
+        -h|--help)
+            sed -n '2,/^$/{ s/^# \?//; p }' "$0"
+            exit 0
+            ;;
+        *)
+            echo "Unknown option: $1" >&2
+            exit 1
+            ;;
+    esac
+done
+
+PLATFORM_PAIR="${PLATFORM//\//-}"
+BASE_CACHE_DIR="${CACHE_DIR}/${PLATFORM_PAIR}-base"
+CORE_CACHE_DIR="${CACHE_DIR}/${PLATFORM_PAIR}-core"
+
+echo "==> Configuration:"
+echo "    Platform:   $PLATFORM"
+echo "    Base tag:   $BASE_TAG"
+echo "    Core tag:   $CORE_TAG"
+echo "    Core dir:   $CORE_DIR"
+echo "    Cache dir:  $CACHE_DIR"
+echo "    Base only:  $BASE_ONLY"
+echo "    Deploy to:  ${DEPLOY_TARGET:-<none>}"
+echo ""
+
+echo "==> Building blueos-base ($PLATFORM)..."
+
+if [ "$BASE_ONLY" = true ]; then
+    docker buildx build \
+        --platform "$PLATFORM" \
+        --load \
+        --cache-from "type=local,src=${BASE_CACHE_DIR}" \
+        --cache-to "type=local,dest=${BASE_CACHE_DIR},mode=max" \
+        -t "$BASE_TAG" \
+        "$SCRIPT_DIR"
+    echo "==> Done (base only). Image: $BASE_TAG"
+    exit 0
+fi
+
+# The docker-container buildx driver can't resolve FROM references against the
+# host Docker daemon's image store.  Export the base image as both a Docker
+# daemon image (type=docker, equivalent to --load) and an OCI layout on disk
+# so the core build can reference it via --build-context ... = oci-layout://...
+BASE_OCI_DIR="${CACHE_DIR}/${PLATFORM_PAIR}-base-oci"
+docker buildx build \
+    --platform "$PLATFORM" \
+    --output type=docker \
+    --output "type=oci,dest=${BASE_OCI_DIR}.tar" \
+    --cache-from "type=local,src=${BASE_CACHE_DIR}" \
+    --cache-to "type=local,dest=${BASE_CACHE_DIR},mode=max" \
+    -t "$BASE_TAG" \
+    "$SCRIPT_DIR"
+
+rm -rf "$BASE_OCI_DIR"
+mkdir -p "$BASE_OCI_DIR"
+tar -xf "${BASE_OCI_DIR}.tar" -C "$BASE_OCI_DIR"
+rm -f "${BASE_OCI_DIR}.tar"
+
+if [ ! -f "$CORE_DIR/Dockerfile" ]; then
+    echo "Error: Core Dockerfile not found at $CORE_DIR/Dockerfile" >&2
+    echo "Set CORE_DIR to point to the BlueOS-docker/core directory." >&2
+    exit 1
+fi
+
+echo "==> Building blueos-core ($PLATFORM)..."
+docker buildx build \
+    --platform "$PLATFORM" \
+    --load \
+    --cache-from "type=local,src=${CORE_CACHE_DIR}" \
+    --cache-to "type=local,dest=${CORE_CACHE_DIR},mode=max" \
+    --build-arg "BASE_IMAGE=$BASE_TAG" \
+    --build-context "${BASE_TAG}=oci-layout://${BASE_OCI_DIR}" \
+    --build-arg "GIT_DESCRIBE_TAGS=0.0.0-dev-0-g00000000" \
+    --build-arg "VITE_APP_GIT_DESCRIBE=heads/dev-0-g00000000" \
+    -t "$CORE_TAG" \
+    "$CORE_DIR"
+
+echo "==> Done! Images:"
+echo "    $BASE_TAG"
+echo "    $CORE_TAG"
+
+if [ -n "$DEPLOY_TARGET" ]; then
+    echo ""
+    echo "==> Deploying $CORE_TAG to $DEPLOY_TARGET..."
+    docker save "$CORE_TAG" | ssh "$DEPLOY_TARGET" docker load
+    echo "==> Deployed successfully."
+fi

--- a/dev-push.sh
+++ b/dev-push.sh
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+#
+# Build blueos-base and blueos-core for multiple platforms and push to Docker Hub.
+#
+# Requires QEMU binfmt handlers for cross-platform builds. Install them with:
+#   docker run --rm --privileged tonistiigi/binfmt --install arm,arm64
+#
+# Usage:
+#   ./dev-push.sh <tag>                              # push as joaoantoniocardoso/blueos-core:<tag>
+#   ./dev-push.sh 1.4.4-next.4                       # example
+#   PLATFORMS="linux/arm/v7" ./dev-push.sh <tag>      # single platform
+#   REPO=myuser/blueos-core ./dev-push.sh <tag>       # custom repo
+#   CORE_DIR=../BlueOS-docker/core ./dev-push.sh <tag>
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+PLATFORMS="${PLATFORMS:-linux/arm/v7,linux/arm64}"
+BASE_TAG="${BASE_TAG:-blueos-base:dev}"
+REPO="${REPO:-joaoantoniocardoso/blueos-core}"
+CORE_DIR="${CORE_DIR:-${SCRIPT_DIR}/../BlueOS-docker/core}"
+CACHE_DIR="${CACHE_DIR:-${SCRIPT_DIR}/.buildx-cache}"
+BUILDER="${BUILDER:-multiarch-builder}"
+
+if [[ $# -lt 1 ]] || [[ "$1" == "-h" ]] || [[ "$1" == "--help" ]]; then
+    sed -n '2,/^$/{ s/^# \?//; p }' "$0"
+    exit 0
+fi
+
+PUSH_TAG="$1"
+FULL_TAG="${REPO}:${PUSH_TAG}"
+
+if [ ! -f "$CORE_DIR/Dockerfile" ]; then
+    echo "Error: Core Dockerfile not found at $CORE_DIR/Dockerfile" >&2
+    echo "Set CORE_DIR to point to the BlueOS-docker/core directory." >&2
+    exit 1
+fi
+
+# Collect per-platform cache-from flags
+CACHE_FROM_BASE=()
+CACHE_FROM_CORE=()
+IFS=',' read -ra PLAT_LIST <<< "$PLATFORMS"
+for plat in "${PLAT_LIST[@]}"; do
+    pair="${plat//\//-}"
+    base_cache="${CACHE_DIR}/${pair}-base"
+    core_cache="${CACHE_DIR}/${pair}-core"
+    [[ -d "$base_cache" ]] && CACHE_FROM_BASE+=(--cache-from "type=local,src=${base_cache}")
+    [[ -d "$core_cache" ]] && CACHE_FROM_CORE+=(--cache-from "type=local,src=${core_cache}")
+done
+
+echo "==> Configuration:"
+echo "    Platforms:  $PLATFORMS"
+echo "    Base tag:   $BASE_TAG"
+echo "    Push tag:   $FULL_TAG"
+echo "    Core dir:   $CORE_DIR"
+echo "    Cache dir:  $CACHE_DIR"
+echo "    Builder:    $BUILDER"
+echo ""
+
+# Build base for all platforms as an OCI layout so the core build can
+# reference it via --build-context regardless of the buildx driver.
+BASE_OCI_DIR="${CACHE_DIR}/multiarch-base-oci"
+
+echo "==> Building ${BASE_TAG} (${PLATFORMS}) as OCI layout..."
+docker buildx build \
+    --builder "$BUILDER" \
+    --platform "$PLATFORMS" \
+    --output "type=oci,dest=${BASE_OCI_DIR}.tar" \
+    "${CACHE_FROM_BASE[@]}" \
+    -t "$BASE_TAG" \
+    "$SCRIPT_DIR"
+
+rm -rf "$BASE_OCI_DIR"
+mkdir -p "$BASE_OCI_DIR"
+tar -xf "${BASE_OCI_DIR}.tar" -C "$BASE_OCI_DIR"
+rm -f "${BASE_OCI_DIR}.tar"
+
+echo "==> Building and pushing ${FULL_TAG} (${PLATFORMS})..."
+docker buildx build \
+    --builder "$BUILDER" \
+    --platform "$PLATFORMS" \
+    --push \
+    "${CACHE_FROM_CORE[@]}" \
+    --build-arg "BASE_IMAGE=${BASE_TAG}" \
+    --build-context "${BASE_TAG}=oci-layout://${BASE_OCI_DIR}" \
+    --build-arg "GIT_DESCRIBE_TAGS=0.0.0-dev-0-g00000000" \
+    --build-arg "VITE_APP_GIT_DESCRIBE=heads/dev-0-g00000000" \
+    -t "$FULL_TAG" \
+    "$CORE_DIR"
+
+echo ""
+echo "==> Pushed: $FULL_TAG"
+echo "    Verify: docker buildx imagetools inspect $FULL_TAG"


### PR DESCRIPTION
## Summary

Add two helper scripts for building and testing `blueos-base` + `blueos-core` locally without needing to push intermediate images to a registry.

- **`dev-build.sh`** -- Build both images locally for a single platform, with optional `--deploy` to push the result to a target device via SSH. Supports `--base-only` for iterating on just the base image.
- **`dev-push.sh`** -- Build for multiple platforms and push to Docker Hub (useful for sharing dev builds).

Both scripts use buildx cache (`type=local`) and OCI layout exports so the core build can reference the locally-built base image via `--build-context`.

**Companion PR:** These scripts consume the `BASE_IMAGE` build-arg introduced in [bluerobotics/BlueOS#3815](https://github.com/bluerobotics/BlueOS/pull/3815).

---

This change is part of the development branch that improved WebRTC performance in BlueOS.